### PR TITLE
feat: PROJECT1/Priority Scheduling 구현

### DIFF
--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -10,33 +10,35 @@ struct semaphore {
 	struct list waiters;        /* List of waiting threads. */
 };
 
-void sema_init (struct semaphore *, unsigned value);
-void sema_down (struct semaphore *);
-bool sema_try_down (struct semaphore *);
-void sema_up (struct semaphore *);
-void sema_self_test (void);
+void sema_init(struct semaphore*, unsigned value);
+void sema_down(struct semaphore*);
+bool sema_try_down(struct semaphore*);
+void sema_up(struct semaphore*);
+void sema_self_test(void);
 
 /* Lock. */
 struct lock {
-	struct thread *holder;      /* Thread holding lock (for debugging). */
+	struct thread* holder;      /* Thread holding lock (for debugging). */
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
 };
 
-void lock_init (struct lock *);
-void lock_acquire (struct lock *);
-bool lock_try_acquire (struct lock *);
-void lock_release (struct lock *);
-bool lock_held_by_current_thread (const struct lock *);
+void lock_init(struct lock*);
+void lock_acquire(struct lock*);
+bool lock_try_acquire(struct lock*);
+void lock_release(struct lock*);
+bool lock_held_by_current_thread(const struct lock*);
 
 /* Condition variable. */
 struct condition {
 	struct list waiters;        /* List of waiting threads. */
 };
 
-void cond_init (struct condition *);
-void cond_wait (struct condition *, struct lock *);
-void cond_signal (struct condition *, struct lock *);
-void cond_broadcast (struct condition *, struct lock *);
+void cond_init(struct condition*);
+void cond_wait(struct condition*, struct lock*);
+void cond_signal(struct condition*, struct lock*);
+void cond_broadcast(struct condition*, struct lock*);
+
+void refresh_priority(void);
 
 /* Optimization barrier.
  *

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -19,7 +19,7 @@ enum thread_status {
 };
 
 /* Thread identifier type.
-   You can redefine this to whatever type you like. */
+	 You can redefine this to whatever type you like. */
 typedef int tid_t;
 #define TID_ERROR ((tid_t) -1)          /* Error value for tid_t. */
 
@@ -79,12 +79,12 @@ typedef int tid_t;
  * the `magic' member of the running thread's `struct thread' is
  * set to THREAD_MAGIC.  Stack overflow will normally change this
  * value, triggering the assertion. */
-/* The `elem' member has a dual purpose.  It can be an element in
- * the run queue (thread.c), or it can be an element in a
- * semaphore wait list (synch.c).  It can be used these two ways
- * only because they are mutually exclusive: only a thread in the
- * ready state is on the run queue, whereas only a thread in the
- * blocked state is on a semaphore wait list. */
+ /* The `elem' member has a dual purpose.  It can be an element in
+	* the run queue (thread.c), or it can be an element in a
+	* semaphore wait list (synch.c).  It can be used these two ways
+	* only because they are mutually exclusive: only a thread in the
+	* ready state is on the run queue, whereas only a thread in the
+	* blocked state is on a semaphore wait list. */
 struct thread {
 	/* Owned by thread.c. */
 	tid_t tid;                          /* Thread identifier. */
@@ -97,7 +97,7 @@ struct thread {
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
-	uint64_t *pml4;                     /* Page map level 4 */
+	uint64_t* pml4;                     /* Page map level 4 */
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */
@@ -110,37 +110,40 @@ struct thread {
 };
 
 /* If false (default), use round-robin scheduler.
-   If true, use multi-level feedback queue scheduler.
-   Controlled by kernel command-line option "-o mlfqs". */
+	 If true, use multi-level feedback queue scheduler.
+	 Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
 
-void thread_init (void);
-void thread_start (void);
+void thread_init(void);
+void thread_start(void);
 
-void thread_tick (void);
-void thread_print_stats (void);
+void thread_tick(void);
+void thread_print_stats(void);
 
-typedef void thread_func (void *aux);
-tid_t thread_create (const char *name, int priority, thread_func *, void *);
+typedef void thread_func(void* aux);
+tid_t thread_create(const char* name, int priority, thread_func*, void*);
 
-void thread_block (void);
-void thread_unblock (struct thread *);
+void thread_block(void);
+void thread_unblock(struct thread*);
 
-struct thread *thread_current (void);
-tid_t thread_tid (void);
-const char *thread_name (void);
+struct thread* thread_current(void);
+tid_t thread_tid(void);
+const char* thread_name(void);
 
-void thread_exit (void) NO_RETURN;
-void thread_yield (void);
+void thread_exit(void) NO_RETURN;
+void thread_yield(void);
 
-int thread_get_priority (void);
-void thread_set_priority (int);
+int thread_get_priority(void);
+void thread_set_priority(int);
 
-int thread_get_nice (void);
-void thread_set_nice (int);
-int thread_get_recent_cpu (void);
-int thread_get_load_avg (void);
+int thread_get_nice(void);
+void thread_set_nice(int);
+int thread_get_recent_cpu(void);
+int thread_get_load_avg(void);
 
-void do_iret (struct intr_frame *tf);
+void do_iret(struct intr_frame* tf);
+
+bool thread_compare_priority(const struct list_elem* a, const struct list_elem* b,
+	void* aux UNUSED);
 
 #endif /* threads/thread.h */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -92,6 +92,12 @@ struct thread {
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
 
+	/* donation을 위하여 선언 */
+	int original_priority;
+	struct lock* wait_on_lock;
+	struct list donations;
+	struct list_elem donation_elem;
+
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
 
@@ -145,5 +151,6 @@ void do_iret(struct intr_frame* tf);
 
 bool thread_compare_priority(const struct list_elem* a, const struct list_elem* b,
 	void* aux UNUSED);
+void thread_test_preemption(void);
 
 #endif /* threads/thread.h */

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -1,30 +1,30 @@
 /* This file is derived from source code for the Nachos
-   instructional operating system.  The Nachos copyright notice
-   is reproduced in full below. */
+	 instructional operating system.  The Nachos copyright notice
+	 is reproduced in full below. */
 
-/* Copyright (c) 1992-1996 The Regents of the University of California.
-   All rights reserved.
+	 /* Copyright (c) 1992-1996 The Regents of the University of California.
+			All rights reserved.
 
-   Permission to use, copy, modify, and distribute this software
-   and its documentation for any purpose, without fee, and
-   without written agreement is hereby granted, provided that the
-   above copyright notice and the following two paragraphs appear
-   in all copies of this software.
+			Permission to use, copy, modify, and distribute this software
+			and its documentation for any purpose, without fee, and
+			without written agreement is hereby granted, provided that the
+			above copyright notice and the following two paragraphs appear
+			in all copies of this software.
 
-   IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO
-   ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR
-   CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OF THIS SOFTWARE
-   AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA
-   HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+			IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO
+			ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR
+			CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OF THIS SOFTWARE
+			AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA
+			HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-   THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
-   WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-   PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS"
-   BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO
-   PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
-   MODIFICATIONS.
-   */
+			THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY
+			WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+			WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+			PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS"
+			BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO
+			PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+			MODIFICATIONS.
+			*/
 
 #include "threads/synch.h"
 #include <stdio.h>
@@ -32,60 +32,63 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
-/* Initializes semaphore SEMA to VALUE.  A semaphore is a
-   nonnegative integer along with two atomic operators for
-   manipulating it:
+			/* Initializes semaphore SEMA to VALUE.  A semaphore is a
+					nonnegative integer along with two atomic operators for
+					manipulating it:
 
-   - down or "P": wait for the value to become positive, then
-   decrement it.
+					- down or "P": wait for the value to become positive, then
+					decrement it.
 
-   - up or "V": increment the value (and wake up one waiting
-   thread, if any). */
+					- up or "V": increment the value (and wake up one waiting
+					thread, if any). */
+
 void
-sema_init (struct semaphore *sema, unsigned value) {
-	ASSERT (sema != NULL);
+sema_init(struct semaphore* sema, unsigned value) {
+	ASSERT(sema != NULL);
 
 	sema->value = value;
-	list_init (&sema->waiters);
+	list_init(&sema->waiters);
 }
 
 /* Down or "P" operation on a semaphore.  Waits for SEMA's value
-   to become positive and then atomically decrements it.
+	 to become positive and then atomically decrements it.
 
-   This function may sleep, so it must not be called within an
-   interrupt handler.  This function may be called with
-   interrupts disabled, but if it sleeps then the next scheduled
-   thread will probably turn interrupts back on. This is
-   sema_down function. */
+	 This function may sleep, so it must not be called within an
+	 interrupt handler.  This function may be called with
+	 interrupts disabled, but if it sleeps then the next scheduled
+	 thread will probably turn interrupts back on. This is
+	 sema_down function. */
 void
-sema_down (struct semaphore *sema) {
+sema_down(struct semaphore* sema) {
 	enum intr_level old_level;
 
-	ASSERT (sema != NULL);
-	ASSERT (!intr_context ());
+	ASSERT(sema != NULL);
+	ASSERT(!intr_context());
 
-	old_level = intr_disable ();
+	old_level = intr_disable();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
-		thread_block ();
+		// list_push_back(&sema->waiters, &thread_current()->elem);
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, thread_compare_priority, NULL);
+		thread_block();
 	}
+
 	sema->value--;
-	intr_set_level (old_level);
+	intr_set_level(old_level);
 }
 
 /* Down or "P" operation on a semaphore, but only if the
-   semaphore is not already 0.  Returns true if the semaphore is
-   decremented, false otherwise.
+	 semaphore is not already 0.  Returns true if the semaphore is
+	 decremented, false otherwise.
 
-   This function may be called from an interrupt handler. */
+	 This function may be called from an interrupt handler. */
 bool
-sema_try_down (struct semaphore *sema) {
+sema_try_down(struct semaphore* sema) {
 	enum intr_level old_level;
 	bool success;
 
-	ASSERT (sema != NULL);
+	ASSERT(sema != NULL);
 
-	old_level = intr_disable ();
+	old_level = intr_disable();
 	if (sema->value > 0)
 	{
 		sema->value--;
@@ -93,149 +96,154 @@ sema_try_down (struct semaphore *sema) {
 	}
 	else
 		success = false;
-	intr_set_level (old_level);
+	intr_set_level(old_level);
 
 	return success;
 }
 
 /* Up or "V" operation on a semaphore.  Increments SEMA's value
-   and wakes up one thread of those waiting for SEMA, if any.
+	 and wakes up one thread of those waiting for SEMA, if any.
 
-   This function may be called from an interrupt handler. */
+	 This function may be called from an interrupt handler. */
 void
-sema_up (struct semaphore *sema) {
+sema_up(struct semaphore* sema) {
 	enum intr_level old_level;
 
-	ASSERT (sema != NULL);
+	ASSERT(sema != NULL);
 
-	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	old_level = intr_disable();
+	if (!list_empty(&sema->waiters)) {
+		list_sort(&sema->waiters, thread_compare_priority, NULL);
+		thread_unblock(list_entry(list_pop_front(&sema->waiters),
+			struct thread, elem));
+
+	}
 	sema->value++;
-	intr_set_level (old_level);
+
+	thread_test_preemption();
+	intr_set_level(old_level);
 }
 
-static void sema_test_helper (void *sema_);
+static void sema_test_helper(void* sema_);
 
 /* Self-test for semaphores that makes control "ping-pong"
-   between a pair of threads.  Insert calls to printf() to see
-   what's going on. */
+	 between a pair of threads.  Insert calls to printf() to see
+	 what's going on. */
 void
-sema_self_test (void) {
+sema_self_test(void) {
 	struct semaphore sema[2];
 	int i;
 
-	printf ("Testing semaphores...");
-	sema_init (&sema[0], 0);
-	sema_init (&sema[1], 0);
-	thread_create ("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
+	printf("Testing semaphores...");
+	sema_init(&sema[0], 0);
+	sema_init(&sema[1], 0);
+	thread_create("sema-test", PRI_DEFAULT, sema_test_helper, &sema);
 	for (i = 0; i < 10; i++)
 	{
-		sema_up (&sema[0]);
-		sema_down (&sema[1]);
+		sema_up(&sema[0]);
+		sema_down(&sema[1]);
 	}
-	printf ("done.\n");
+	printf("done.\n");
 }
 
 /* Thread function used by sema_self_test(). */
 static void
-sema_test_helper (void *sema_) {
-	struct semaphore *sema = sema_;
+sema_test_helper(void* sema_) {
+	struct semaphore* sema = sema_;
 	int i;
 
 	for (i = 0; i < 10; i++)
 	{
-		sema_down (&sema[0]);
-		sema_up (&sema[1]);
+		sema_down(&sema[0]);
+		sema_up(&sema[1]);
 	}
 }
-
-/* Initializes LOCK.  A lock can be held by at most a single
-   thread at any given time.  Our locks are not "recursive", that
-   is, it is an error for the thread currently holding a lock to
-   try to acquire that lock.
 
-   A lock is a specialization of a semaphore with an initial
-   value of 1.  The difference between a lock and such a
-   semaphore is twofold.  First, a semaphore can have a value
-   greater than 1, but a lock can only be owned by a single
-   thread at a time.  Second, a semaphore does not have an owner,
-   meaning that one thread can "down" the semaphore and then
-   another one "up" it, but with a lock the same thread must both
-   acquire and release it.  When these restrictions prove
-   onerous, it's a good sign that a semaphore should be used,
-   instead of a lock. */
+/* Initializes LOCK.  A lock can be held by at most a single
+	 thread at any given time.  Our locks are not "recursive", that
+	 is, it is an error for the thread currently holding a lock to
+	 try to acquire that lock.
+
+	 A lock is a specialization of a semaphore with an initial
+	 value of 1.  The difference between a lock and such a
+	 semaphore is twofold.  First, a semaphore can have a value
+	 greater than 1, but a lock can only be owned by a single
+	 thread at a time.  Second, a semaphore does not have an owner,
+	 meaning that one thread can "down" the semaphore and then
+	 another one "up" it, but with a lock the same thread must both
+	 acquire and release it.  When these restrictions prove
+	 onerous, it's a good sign that a semaphore should be used,
+	 instead of a lock. */
 void
-lock_init (struct lock *lock) {
-	ASSERT (lock != NULL);
+lock_init(struct lock* lock) {
+	ASSERT(lock != NULL);
 
 	lock->holder = NULL;
-	sema_init (&lock->semaphore, 1);
+	sema_init(&lock->semaphore, 1);
 }
 
 /* Acquires LOCK, sleeping until it becomes available if
-   necessary.  The lock must not already be held by the current
-   thread.
+	 necessary.  The lock must not already be held by the current
+	 thread.
 
-   This function may sleep, so it must not be called within an
-   interrupt handler.  This function may be called with
-   interrupts disabled, but interrupts will be turned back on if
-   we need to sleep. */
+	 This function may sleep, so it must not be called within an
+	 interrupt handler.  This function may be called with
+	 interrupts disabled, but interrupts will be turned back on if
+	 we need to sleep. */
 void
-lock_acquire (struct lock *lock) {
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (!lock_held_by_current_thread (lock));
+lock_acquire(struct lock* lock) {
+	ASSERT(lock != NULL);
+	ASSERT(!intr_context());
+	ASSERT(!lock_held_by_current_thread(lock));
 
-	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+	sema_down(&lock->semaphore);
+	lock->holder = thread_current();
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
-   on failure.  The lock must not already be held by the current
-   thread.
+	 on failure.  The lock must not already be held by the current
+	 thread.
 
-   This function will not sleep, so it may be called within an
-   interrupt handler. */
+	 This function will not sleep, so it may be called within an
+	 interrupt handler. */
 bool
-lock_try_acquire (struct lock *lock) {
+lock_try_acquire(struct lock* lock) {
 	bool success;
 
-	ASSERT (lock != NULL);
-	ASSERT (!lock_held_by_current_thread (lock));
+	ASSERT(lock != NULL);
+	ASSERT(!lock_held_by_current_thread(lock));
 
-	success = sema_try_down (&lock->semaphore);
+	success = sema_try_down(&lock->semaphore);
 	if (success)
-		lock->holder = thread_current ();
+		lock->holder = thread_current();
 	return success;
 }
 
 /* Releases LOCK, which must be owned by the current thread.
-   This is lock_release function.
+	 This is lock_release function.
 
-   An interrupt handler cannot acquire a lock, so it does not
-   make sense to try to release a lock within an interrupt
-   handler. */
+	 An interrupt handler cannot acquire a lock, so it does not
+	 make sense to try to release a lock within an interrupt
+	 handler. */
 void
-lock_release (struct lock *lock) {
-	ASSERT (lock != NULL);
-	ASSERT (lock_held_by_current_thread (lock));
+lock_release(struct lock* lock) {
+	ASSERT(lock != NULL);
+	ASSERT(lock_held_by_current_thread(lock));
 
 	lock->holder = NULL;
-	sema_up (&lock->semaphore);
+	sema_up(&lock->semaphore);
 }
 
 /* Returns true if the current thread holds LOCK, false
-   otherwise.  (Note that testing whether some other thread holds
-   a lock would be racy.) */
+	 otherwise.  (Note that testing whether some other thread holds
+	 a lock would be racy.) */
 bool
-lock_held_by_current_thread (const struct lock *lock) {
-	ASSERT (lock != NULL);
+lock_held_by_current_thread(const struct lock* lock) {
+	ASSERT(lock != NULL);
 
-	return lock->holder == thread_current ();
+	return lock->holder == thread_current();
 }
-
+
 /* One semaphore in a list. */
 struct semaphore_elem {
 	struct list_elem elem;              /* List element. */
@@ -243,81 +251,108 @@ struct semaphore_elem {
 };
 
 /* Initializes condition variable COND.  A condition variable
-   allows one piece of code to signal a condition and cooperating
-   code to receive the signal and act upon it. */
+	 allows one piece of code to signal a condition and cooperating
+	 code to receive the signal and act upon it. */
 void
-cond_init (struct condition *cond) {
-	ASSERT (cond != NULL);
+cond_init(struct condition* cond) {
+	ASSERT(cond != NULL);
 
-	list_init (&cond->waiters);
+	list_init(&cond->waiters);
 }
 
 /* Atomically releases LOCK and waits for COND to be signaled by
-   some other piece of code.  After COND is signaled, LOCK is
-   reacquired before returning.  LOCK must be held before calling
-   this function.
+	 some other piece of code.  After COND is signaled, LOCK is
+	 reacquired before returning.  LOCK must be held before calling
+	 this function.
 
-   The monitor implemented by this function is "Mesa" style, not
-   "Hoare" style, that is, sending and receiving a signal are not
-   an atomic operation.  Thus, typically the caller must recheck
-   the condition after the wait completes and, if necessary, wait
-   again.
+	 The monitor implemented by this function is "Mesa" style, not
+	 "Hoare" style, that is, sending and receiving a signal are not
+	 an atomic operation.  Thus, typically the caller must recheck
+	 the condition after the wait completes and, if necessary, wait
+	 again.
 
-   A given condition variable is associated with only a single
-   lock, but one lock may be associated with any number of
-   condition variables.  That is, there is a one-to-many mapping
-   from locks to condition variables.
+	 A given condition variable is associated with only a single
+	 lock, but one lock may be associated with any number of
+	 condition variables.  That is, there is a one-to-many mapping
+	 from locks to condition variables.
 
-   This function may sleep, so it must not be called within an
-   interrupt handler.  This function may be called with
-   interrupts disabled, but interrupts will be turned back on if
-   we need to sleep. */
+	 This function may sleep, so it must not be called within an
+	 interrupt handler.  This function may be called with
+	 interrupts disabled, but interrupts will be turned back on if
+	 we need to sleep. */
+void sema_compare_priority(const struct list_elem* a, const struct list_elem* b,
+	void* aux UNUSED) {
+	struct semaphore_elem* sema_a = list_entry(a, struct semaphore_elem, elem);
+	struct semaphore_elem* sema_b = list_entry(b, struct semaphore_elem, elem);
+
+	struct list* waiters_in_sema_a = &sema_a->semaphore.waiters;
+	struct list* waiters_in_sema_b = &sema_b->semaphore.waiters;
+
+	struct thread* max_sema_a = list_entry(list_front(&waiters_in_sema_a), struct thread, elem);
+	struct thread* max_sema_b = list_entry(list_front(&waiters_in_sema_b), struct thread, elem);
+
+	return max_sema_a->priority > max_sema_b->priority;
+}
+
 void
-cond_wait (struct condition *cond, struct lock *lock) {
+cond_wait(struct condition* cond, struct lock* lock) {
 	struct semaphore_elem waiter;
 
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (lock_held_by_current_thread (lock));
+	ASSERT(cond != NULL);
+	ASSERT(lock != NULL);
+	ASSERT(!intr_context());
+	ASSERT(lock_held_by_current_thread(lock));
 
-	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
-	lock_release (lock);
-	sema_down (&waiter.semaphore);
-	lock_acquire (lock);
+	sema_init(&waiter.semaphore, 0);
+	// list_push_back(&cond->waiters, &waiter.elem);
+	list_insert_ordered(&cond->waiters, &waiter.elem, sema_compare_priority, NULL);
+	lock_release(lock);
+	sema_down(&waiter.semaphore);
+	lock_acquire(lock);
 }
 
 /* If any threads are waiting on COND (protected by LOCK), then
-   this function signals one of them to wake up from its wait.
-   LOCK must be held before calling this function.
+	 this function signals one of them to wake up from its wait.
+	 LOCK must be held before calling this function.
 
-   An interrupt handler cannot acquire a lock, so it does not
-   make sense to try to signal a condition variable within an
-   interrupt handler. */
+	 An interrupt handler cannot acquire a lock, so it does not
+	 make sense to try to signal a condition variable within an
+	 interrupt handler. */
+
+	 /* COND(LOCK으로 보호됨)를 대기 중인 스레드가 있는 경우,
+	 이 함수는 해당 스레드 중 하나에 대기에서 깨어나도록 신호를 보냅니다.
+	 이 함수를 호출하기 전에 LOCK을 유지해야 합니다.
+
+	 인터럽트 핸들러는 잠금을 획득할 수 없으므로
+	 인터럽트 핸들러 내에서 조건 변수에 신호를 보내는 것은 의미가 없습니다. */
+
 void
-cond_signal (struct condition *cond, struct lock *lock UNUSED) {
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
-	ASSERT (!intr_context ());
-	ASSERT (lock_held_by_current_thread (lock));
+cond_signal(struct condition* cond, struct lock* lock UNUSED) {
+	ASSERT(cond != NULL);
+	ASSERT(lock != NULL);
+	ASSERT(!intr_context());
+	ASSERT(lock_held_by_current_thread(lock));
 
-	if (!list_empty (&cond->waiters))
-		sema_up (&list_entry (list_pop_front (&cond->waiters),
-					struct semaphore_elem, elem)->semaphore);
+	if (!list_empty(&cond->waiters))
+	{
+		list_sort(&cond->waiters, sema_compare_priority, NULL);
+
+		sema_up(&list_entry(list_pop_front(&cond->waiters),
+			struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by
-   LOCK).  LOCK must be held before calling this function.
+	 LOCK).  LOCK must be held before calling this function.
 
-   An interrupt handler cannot acquire a lock, so it does not
-   make sense to try to signal a condition variable within an
-   interrupt handler. */
+	 An interrupt handler cannot acquire a lock, so it does not
+	 make sense to try to signal a condition variable within an
+	 interrupt handler. */
 void
-cond_broadcast (struct condition *cond, struct lock *lock) {
-	ASSERT (cond != NULL);
-	ASSERT (lock != NULL);
+cond_broadcast(struct condition* cond, struct lock* lock) {
+	ASSERT(cond != NULL);
+	ASSERT(lock != NULL);
 
-	while (!list_empty (&cond->waiters))
-		cond_signal (cond, lock);
+	while (!list_empty(&cond->waiters))
+		cond_signal(cond, lock);
 }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -329,7 +329,8 @@ thread_yield(void) {
 void
 thread_set_priority(int new_priority) {
   // 우선순위가 낮아졌다면 우선순위가 높은 쓰레드에게 넘김
-  thread_current()->priority = new_priority;
+  thread_current()->original_priority = new_priority; // donation을 위한 추가
+  refresh_priority(); // 변경된 우선순위 반영하여 다시 donation
   thread_test_preemption();
 }
 
@@ -433,6 +434,9 @@ init_thread(struct thread* t, const char* name, int priority) {
   strlcpy(t->name, name, sizeof t->name);
   t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void*);
   t->priority = priority;
+  t->original_priority = priority;
+  t->wait_on_lock = NULL;
+  list_init(&t->donations);
   t->magic = THREAD_MAGIC;
 }
 

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -1,16 +1,16 @@
 #include "threads/thread.h"
-#include <debug.h>
-#include <stddef.h>
-#include <random.h>
-#include <stdio.h>
-#include <string.h>
+#include "intrinsic.h"
 #include "threads/flags.h"
 #include "threads/interrupt.h"
 #include "threads/intr-stubs.h"
 #include "threads/palloc.h"
 #include "threads/synch.h"
 #include "threads/vaddr.h"
-#include "intrinsic.h"
+#include <debug.h>
+#include <random.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
 #ifdef USERPROG
 #include "userprog/process.h"
 #endif
@@ -20,19 +20,19 @@
    of thread.h for details. */
 #define THREAD_MAGIC 0xcd6abf4b
 
-/* Random value for basic thread
-   Do not modify this value. */
+   /* Random value for basic thread
+     Do not modify this value. */
 #define THREAD_BASIC 0xd42df210
 
-/* List of processes in THREAD_READY state, that is, processes
-   that are ready to run but not actually running. */
+     /* List of processes in THREAD_READY state, that is, processes
+         that are ready to run but not actually running. */
 static struct list ready_list;
 
 /* Idle thread. */
-static struct thread *idle_thread;
+static struct thread* idle_thread;
 
 /* Initial thread, the thread running init.c:main(). */
-static struct thread *initial_thread;
+static struct thread* initial_thread;
 
 /* Lock used by allocate_tid(). */
 static struct lock tid_lock;
@@ -41,27 +41,38 @@ static struct lock tid_lock;
 static struct list destruction_req;
 
 /* Statistics. */
-static long long idle_ticks;    /* # of timer ticks spent idle. */
-static long long kernel_ticks;  /* # of timer ticks in kernel threads. */
-static long long user_ticks;    /* # of timer ticks in user programs. */
+static long long idle_ticks;   /* # of timer ticks spent idle. */
+static long long kernel_ticks; /* # of timer ticks in kernel threads. */
+static long long user_ticks;   /* # of timer ticks in user programs. */
 
 /* Scheduling. */
-#define TIME_SLICE 4            /* # of timer ticks to give each thread. */
-static unsigned thread_ticks;   /* # of timer ticks since last yield. */
+#define TIME_SLICE 4          /* # of timer ticks to give each thread. */
+static unsigned thread_ticks; /* # of timer ticks since last yield. */
 
 /* If false (default), use round-robin scheduler.
-   If true, use multi-level feedback queue scheduler.
-   Controlled by kernel command-line option "-o mlfqs". */
+If true, use multi-level feedback queue
+scheduler. Controlled by kernel command-line option "-o mlfqs". */
 bool thread_mlfqs;
 
-static void kernel_thread (thread_func *, void *aux);
+static void kernel_thread(thread_func*, void* aux);
 
-static void idle (void *aux UNUSED);
-static struct thread *next_thread_to_run (void);
-static void init_thread (struct thread *, const char *name, int priority);
+static void idle(void* aux UNUSED);
+static struct thread* next_thread_to_run(void);
+static void init_thread(struct thread*, const char* name, int priority);
 static void do_schedule(int status);
-static void schedule (void);
-static tid_t allocate_tid (void);
+static void schedule(void);
+static tid_t allocate_tid(void);
+
+void debug_ready_list(void) {
+  printf("\n===== Ready List Status =====\n");
+  struct list_elem* e = list_begin(&ready_list);
+  while (e != list_end(&ready_list)) {
+    struct thread* t = list_entry(e, struct thread, elem);
+    printf("Thread: %s | Priority: %d\n", t->name, t->priority);
+    e = list_next(e);
+  }
+  printf("===== End of Ready List =====\n\n");
+}
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -71,12 +82,11 @@ static tid_t allocate_tid (void);
  * down to the start of a page.  Since `struct thread' is
  * always at the beginning of a page and the stack pointer is
  * somewhere in the middle, this locates the curent thread. */
-#define running_thread() ((struct thread *) (pg_round_down (rrsp ())))
+#define running_thread() ((struct thread *)(pg_round_down(rrsp())))
 
-
-// Global descriptor table for the thread_start.
-// Because the gdt will be setup after the thread_init, we should
-// setup temporal gdt first.
+ // Global descriptor table for the thread_start.
+ // Because the gdt will be setup after the thread_init, we should
+ // setup temporal gdt first.
 static uint64_t gdt[3] = { 0, 0x00af9a000000ffff, 0x00cf92000000ffff };
 
 /* Initializes the threading system by transforming the code
@@ -93,72 +103,79 @@ static uint64_t gdt[3] = { 0, 0x00af9a000000ffff, 0x00cf92000000ffff };
    It is not safe to call thread_current() until this function
    finishes. */
 void
-thread_init (void) {
-	ASSERT (intr_get_level () == INTR_OFF);
+thread_init(void) {
+  ASSERT(intr_get_level() == INTR_OFF);
 
-	/* Reload the temporal gdt for the kernel
-	 * This gdt does not include the user context.
-	 * The kernel will rebuild the gdt with user context, in gdt_init (). */
-	struct desc_ptr gdt_ds = {
-		.size = sizeof (gdt) - 1,
-		.address = (uint64_t) gdt
-	};
-	lgdt (&gdt_ds);
+  /* Reload the temporal gdt for the kernel
+   * This gdt does not include the user context.
+   * The kernel will rebuild the gdt with user context, in gdt_init (). */
+  struct desc_ptr gdt_ds = {
+    .size = sizeof(gdt) - 1,
+    .address = (uint64_t)gdt
+  };
+  lgdt(&gdt_ds);
 
-	/* Init the globla thread context */
-	lock_init (&tid_lock);
-	list_init (&ready_list);
-	list_init (&destruction_req);
+  /* Init the globla thread context */
+  lock_init(&tid_lock);
+  list_init(&ready_list);
+  list_init(&destruction_req);
 
-	/* Set up a thread structure for the running thread. */
-	initial_thread = running_thread ();
-	init_thread (initial_thread, "main", PRI_DEFAULT);
-	initial_thread->status = THREAD_RUNNING;
-	initial_thread->tid = allocate_tid ();
+  /* Set up a thread structure for the running thread. */
+  initial_thread = running_thread();
+  init_thread(initial_thread, "main", PRI_DEFAULT);
+  initial_thread->status = THREAD_RUNNING;
+  initial_thread->tid = allocate_tid();
 }
 
 /* Starts preemptive thread scheduling by enabling interrupts.
    Also creates the idle thread. */
 void
-thread_start (void) {
-	/* Create the idle thread. */
-	struct semaphore idle_started;
-	sema_init (&idle_started, 0);
-	thread_create ("idle", PRI_MIN, idle, &idle_started);
+thread_start(void) {
+  /* Create the idle thread. */
+  struct semaphore idle_started;
+  sema_init(&idle_started, 0);
+  thread_create("idle", PRI_MIN, idle, &idle_started);
 
-	/* Start preemptive thread scheduling. */
-	intr_enable ();
+  /* Start preemptive thread scheduling. */
+  intr_enable();
 
-	/* Wait for the idle thread to initialize idle_thread. */
-	sema_down (&idle_started);
+  /* Wait for the idle thread to initialize idle_thread. */
+  sema_down(&idle_started);
 }
 
 /* Called by the timer interrupt handler at each timer tick.
    Thus, this function runs in an external interrupt context. */
 void
-thread_tick (void) {
-	struct thread *t = thread_current ();
+thread_tick(void) {
+  struct thread* t = thread_current();
 
-	/* Update statistics. */
-	if (t == idle_thread)
-		idle_ticks++;
+  /* Update statistics. */
+  if (t == idle_thread)
+    idle_ticks++;
 #ifdef USERPROG
-	else if (t->pml4 != NULL)
-		user_ticks++;
+  else if (t->pml4 != NULL)
+    user_ticks++;
 #endif
-	else
-		kernel_ticks++;
+  else
+    kernel_ticks++;
 
-	/* Enforce preemption. */
-	if (++thread_ticks >= TIME_SLICE)
-		intr_yield_on_return ();
+  /* Enforce preemption. */
+  if (++thread_ticks >= TIME_SLICE)
+    intr_yield_on_return();
 }
 
 /* Prints thread statistics. */
-void
-thread_print_stats (void) {
-	printf ("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
-			idle_ticks, kernel_ticks, user_ticks);
+void thread_print_stats(void) {
+  printf("Thread: %lld idle ticks, %lld kernel ticks, %lld user ticks\n",
+    idle_ticks, kernel_ticks, user_ticks);
+}
+
+/* ready_list 우선순위 정렬을 위한 서브 함수 */
+bool value_less(const struct list_elem* a, const struct list_elem* b,
+  void* aux UNUSED) {
+  struct thread* data_a = list_entry(a, struct thread, elem);
+  struct thread* data_b = list_entry(b, struct thread, elem);
+  return data_a->priority > data_b->priority;
 }
 
 /* Creates a new kernel thread named NAME with the given initial
@@ -177,37 +194,37 @@ thread_print_stats (void) {
    PRIORITY, but no actual priority scheduling is implemented.
    Priority scheduling is the goal of Problem 1-3. */
 tid_t
-thread_create (const char *name, int priority,
-		thread_func *function, void *aux) {
-	struct thread *t;
-	tid_t tid;
+thread_create(const char* name, int priority,
+  thread_func* function, void* aux) {
+  struct thread* t;
+  tid_t tid;
 
-	ASSERT (function != NULL);
+  ASSERT(function != NULL);
 
-	/* Allocate thread. */
-	t = palloc_get_page (PAL_ZERO);
-	if (t == NULL)
-		return TID_ERROR;
+  /* Allocate thread. */
+  t = palloc_get_page(PAL_ZERO);
+  if (t == NULL)
+    return TID_ERROR;
 
-	/* Initialize thread. */
-	init_thread (t, name, priority);
-	tid = t->tid = allocate_tid ();
+  /* Initialize thread. */
+  init_thread(t, name, priority);
+  tid = t->tid = allocate_tid();
 
-	/* Call the kernel_thread if it scheduled.
-	 * Note) rdi is 1st argument, and rsi is 2nd argument. */
-	t->tf.rip = (uintptr_t) kernel_thread;
-	t->tf.R.rdi = (uint64_t) function;
-	t->tf.R.rsi = (uint64_t) aux;
-	t->tf.ds = SEL_KDSEG;
-	t->tf.es = SEL_KDSEG;
-	t->tf.ss = SEL_KDSEG;
-	t->tf.cs = SEL_KCSEG;
-	t->tf.eflags = FLAG_IF;
+  /* Call the kernel_thread if it scheduled.
+   * Note) rdi is 1st argument, and rsi is 2nd argument. */
+  t->tf.rip = (uintptr_t)kernel_thread;
+  t->tf.R.rdi = (uint64_t)function;
+  t->tf.R.rsi = (uint64_t)aux;
+  t->tf.ds = SEL_KDSEG;
+  t->tf.es = SEL_KDSEG;
+  t->tf.ss = SEL_KDSEG;
+  t->tf.cs = SEL_KCSEG;
+  t->tf.eflags = FLAG_IF;
 
-	/* Add to run queue. */
-	thread_unblock (t);
+  /* Add to run queue. */
+  thread_unblock(t);
 
-	return tid;
+  return tid;
 }
 
 /* Puts the current thread to sleep.  It will not be scheduled
@@ -217,11 +234,11 @@ thread_create (const char *name, int priority,
    is usually a better idea to use one of the synchronization
    primitives in synch.h. */
 void
-thread_block (void) {
-	ASSERT (!intr_context ());
-	ASSERT (intr_get_level () == INTR_OFF);
-	thread_current ()->status = THREAD_BLOCKED;
-	schedule ();
+thread_block(void) {
+  ASSERT(!intr_context());
+  ASSERT(intr_get_level() == INTR_OFF);
+  thread_current()->status = THREAD_BLOCKED;
+  schedule();
 }
 
 /* Transitions a blocked thread T to the ready-to-run state.
@@ -233,118 +250,141 @@ thread_block (void) {
    it may expect that it can atomically unblock a thread and
    update other data. */
 void
-thread_unblock (struct thread *t) {
-	enum intr_level old_level;
+thread_unblock(struct thread* t) {
+  enum intr_level old_level;
 
-	ASSERT (is_thread (t));
+  ASSERT(is_thread(t));
 
-	old_level = intr_disable ();
-	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
-	t->status = THREAD_READY;
-	intr_set_level (old_level);
+  old_level = intr_disable();
+  ASSERT(t->status == THREAD_BLOCKED);
+  // list_push_back(&ready_list, &t->elem);
+  list_insert_ordered(&ready_list, &t->elem, value_less, NULL);
+  t->status = THREAD_READY;
+
+  // 디버깅
+  // debug_ready_list();
+
+  intr_set_level(old_level);
+
+  /*
+  printf("\n===== thread_unblock =====\n");
+  struct list_elem* lst_elem = list_begin(&ready_list);
+
+  while (lst_elem != list_end(&ready_list)) {
+    struct thread* cur = list_entry(lst_elem, struct thread, elem);
+    printf("ready list : %p\n", cur);
+    lst_elem = list_next(lst_elem);
+  }
+  */
 }
 
 /* Returns the name of the running thread. */
-const char *
-thread_name (void) {
-	return thread_current ()->name;
-}
+const char* thread_name(void) { return thread_current()->name; }
 
 /* Returns the running thread.
    This is running_thread() plus a couple of sanity checks.
    See the big comment at the top of thread.h for details. */
-struct thread *
-thread_current (void) {
-	struct thread *t = running_thread ();
+struct thread*
+  thread_current(void) {
+  struct thread* t = running_thread();
 
-	/* Make sure T is really a thread.
-	   If either of these assertions fire, then your thread may
-	   have overflowed its stack.  Each thread has less than 4 kB
-	   of stack, so a few big automatic arrays or moderate
-	   recursion can cause stack overflow. */
-	ASSERT (is_thread (t));
-	ASSERT (t->status == THREAD_RUNNING);
+  /* Make sure T is really a thread.
+     If either of these assertions fire, then your thread may
+     have overflowed its stack.  Each thread has less than 4 kB
+     of stack, so a few big automatic arrays or moderate
+     recursion can cause stack overflow. */
+  ASSERT(is_thread(t));
+  ASSERT(t->status == THREAD_RUNNING);
 
-	return t;
+  return t;
 }
 
 /* Returns the running thread's tid. */
 tid_t
-thread_tid (void) {
-	return thread_current ()->tid;
+thread_tid(void) {
+  return thread_current()->tid;
 }
 
 /* Deschedules the current thread and destroys it.  Never
    returns to the caller. */
 void
-thread_exit (void) {
-	ASSERT (!intr_context ());
+thread_exit(void) {
+  ASSERT(!intr_context());
 
 #ifdef USERPROG
-	process_exit ();
+  process_exit();
 #endif
 
-	/* Just set our status to dying and schedule another process.
-	   We will be destroyed during the call to schedule_tail(). */
-	intr_disable ();
-	do_schedule (THREAD_DYING);
-	NOT_REACHED ();
+  /* Just set our status to dying and schedule another process.
+     We will be destroyed during the call to schedule_tail(). */
+  intr_disable();
+  do_schedule(THREAD_DYING);
+  NOT_REACHED();
 }
 
 /* Yields the CPU.  The current thread is not put to sleep and
    may be scheduled again immediately at the scheduler's whim. */
 void
-thread_yield (void) {
-	struct thread *curr = thread_current ();
-	enum intr_level old_level;
+thread_yield(void) {
+  struct thread* curr = thread_current();
+  enum intr_level old_level;
 
-	ASSERT (!intr_context ());
+  ASSERT(!intr_context());
 
-	old_level = intr_disable ();
-	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
-	do_schedule (THREAD_READY);
-	intr_set_level (old_level);
+  old_level = intr_disable();
+  if (curr != idle_thread)
+    // list_push_back(&ready_list, &curr->elem);
+    list_insert_ordered(&ready_list, &curr->elem, value_less, NULL);
+
+  // 디버깅
+  // debug_ready_list();
+
+  do_schedule(THREAD_READY);
+  intr_set_level(old_level);
 }
 
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
-thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+thread_set_priority(int new_priority) {
+  enum intr_level old_level;
+  old_level = intr_disable();
+
+  // 우선순위가 바뀌면 다시 정렬하기 위해 ready 상태로 보냄
+  thread_current()->priority = new_priority;
+  thread_yield();
+
+  intr_set_level(old_level);
 }
 
 /* Returns the current thread's priority. */
 int
-thread_get_priority (void) {
-	return thread_current ()->priority;
+thread_get_priority(void) {
+  return thread_current()->priority;
 }
 
 /* Sets the current thread's nice value to NICE. */
 void
-thread_set_nice (int nice UNUSED) {
-	/* TODO: Your implementation goes here */
+thread_set_nice(int nice UNUSED) {
+  /* TODO: Your implementation goes here */
 }
 
 /* Returns the current thread's nice value. */
 int
-thread_get_nice (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+thread_get_nice(void) {
+  /* TODO: Your implementation goes here */
+  return 0;
 }
 
 /* Returns 100 times the system load average. */
-int
-thread_get_load_avg (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+int thread_get_load_avg(void) {
+  /* TODO: Your implementation goes here */
+  return 0;
 }
 
 /* Returns 100 times the current thread's recent_cpu value. */
-int
-thread_get_recent_cpu (void) {
-	/* TODO: Your implementation goes here */
-	return 0;
+int thread_get_recent_cpu(void) {
+  /* TODO: Your implementation goes here */
+  return 0;
 }
 
 /* Idle thread.  Executes when no other thread is ready to run.
@@ -357,103 +397,109 @@ thread_get_recent_cpu (void) {
    ready list.  It is returned by next_thread_to_run() as a
    special case when the ready list is empty. */
 static void
-idle (void *idle_started_ UNUSED) {
-	struct semaphore *idle_started = idle_started_;
+idle(void* idle_started_ UNUSED) {
+  struct semaphore* idle_started = idle_started_;
 
-	idle_thread = thread_current ();
-	sema_up (idle_started);
+  idle_thread = thread_current();
+  sema_up(idle_started);
 
-	for (;;) {
-		/* Let someone else run. */
-		intr_disable ();
-		thread_block ();
+  for (;;) {
+    /* Let someone else run. */
+    intr_disable();
+    thread_block();
 
-		/* Re-enable interrupts and wait for the next one.
+    /* Re-enable interrupts and wait for the next one.
 
-		   The `sti' instruction disables interrupts until the
-		   completion of the next instruction, so these two
-		   instructions are executed atomically.  This atomicity is
-		   important; otherwise, an interrupt could be handled
-		   between re-enabling interrupts and waiting for the next
-		   one to occur, wasting as much as one clock tick worth of
-		   time.
+       The `sti' instruction disables interrupts until the
+       completion of the next instruction, so these two
+       instructions are executed atomically.  This atomicity is
+       important; otherwise, an interrupt could be handled
+       between re-enabling interrupts and waiting for the next
+       one to occur, wasting as much as one clock tick worth of
+       time.
 
-		   See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
-		   7.11.1 "HLT Instruction". */
-		asm volatile ("sti; hlt" : : : "memory");
-	}
+       See [IA32-v2a] "HLT", [IA32-v2b] "STI", and [IA32-v3a]
+       7.11.1 "HLT Instruction". */
+    asm volatile ("sti; hlt" : : : "memory");
+  }
 }
 
 /* Function used as the basis for a kernel thread. */
 static void
-kernel_thread (thread_func *function, void *aux) {
-	ASSERT (function != NULL);
+kernel_thread(thread_func* function, void* aux) {
+  ASSERT(function != NULL);
 
-	intr_enable ();       /* The scheduler runs with interrupts off. */
-	function (aux);       /* Execute the thread function. */
-	thread_exit ();       /* If function() returns, kill the thread. */
+  intr_enable();       /* The scheduler runs with interrupts off. */
+  function(aux);       /* Execute the thread function. */
+  thread_exit();       /* If function() returns, kill the thread. */
 }
-
 
 /* Does basic initialization of T as a blocked thread named
    NAME. */
 static void
-init_thread (struct thread *t, const char *name, int priority) {
-	ASSERT (t != NULL);
-	ASSERT (PRI_MIN <= priority && priority <= PRI_MAX);
-	ASSERT (name != NULL);
+init_thread(struct thread* t, const char* name, int priority) {
+  ASSERT(t != NULL);
+  ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
+  ASSERT(name != NULL);
 
-	memset (t, 0, sizeof *t);
-	t->status = THREAD_BLOCKED;
-	strlcpy (t->name, name, sizeof t->name);
-	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
-	t->priority = priority;
-	t->magic = THREAD_MAGIC;
+  memset(t, 0, sizeof * t);
+  t->status = THREAD_BLOCKED;
+  strlcpy(t->name, name, sizeof t->name);
+  t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void*);
+  t->priority = priority;
+  t->magic = THREAD_MAGIC;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should
-   return a thread from the run queue, unless the run queue is
-   empty.  (If the running thread can continue running, then it
-   will be in the run queue.)  If the run queue is empty, return
-   idle_thread. */
-static struct thread *
-next_thread_to_run (void) {
-	if (list_empty (&ready_list))
-		return idle_thread;
-	else
-		return list_entry (list_pop_front (&ready_list), struct thread, elem);
+return a thread from the run queue, unless the run queue is
+empty.  (If the running thread can continue running, then it
+will be in the run queue.)  If the run queue is empty, return
+idle_thread. */
+/* 스케줄링할 다음 스레드를 선택하고 반환합니다.
+실행 대기열이 비어 있지 않은 한, 실행 대기열에서 스레드를 반환해야 합니다. (실행 중인 스레드가 계속 실행될 수 있다면 실행 대기열에 있을 것입니다.)
+실행 대기열이 비어 있으면,idle_thread를 반환합니다. */
+static struct thread* next_thread_to_run(void) {
+  if (list_empty(&ready_list))
+    return idle_thread;
+
+  else {
+    // struct list_elem* max_elem = list_max(&ready_list, value_less, NULL);
+    // list_remove(max_elem);
+    // return list_entry(max_elem, struct thread, elem);
+    return list_entry(list_pop_front(&ready_list), struct thread, elem);
+  }
 }
 
 /* Use iretq to launch the thread */
 void
-do_iret (struct intr_frame *tf) {
-	__asm __volatile(
-			"movq %0, %%rsp\n"
-			"movq 0(%%rsp),%%r15\n"
-			"movq 8(%%rsp),%%r14\n"
-			"movq 16(%%rsp),%%r13\n"
-			"movq 24(%%rsp),%%r12\n"
-			"movq 32(%%rsp),%%r11\n"
-			"movq 40(%%rsp),%%r10\n"
-			"movq 48(%%rsp),%%r9\n"
-			"movq 56(%%rsp),%%r8\n"
-			"movq 64(%%rsp),%%rsi\n"
-			"movq 72(%%rsp),%%rdi\n"
-			"movq 80(%%rsp),%%rbp\n"
-			"movq 88(%%rsp),%%rdx\n"
-			"movq 96(%%rsp),%%rcx\n"
-			"movq 104(%%rsp),%%rbx\n"
-			"movq 112(%%rsp),%%rax\n"
-			"addq $120,%%rsp\n"
-			"movw 8(%%rsp),%%ds\n"
-			"movw (%%rsp),%%es\n"
-			"addq $32, %%rsp\n"
-			"iretq"
-			: : "g" ((uint64_t) tf) : "memory");
+do_iret(struct intr_frame* tf) {
+  __asm __volatile(
+  "movq %0, %%rsp\n"
+    "movq 0(%%rsp),%%r15\n"
+    "movq 8(%%rsp),%%r14\n"
+    "movq 16(%%rsp),%%r13\n"
+    "movq 24(%%rsp),%%r12\n"
+    "movq 32(%%rsp),%%r11\n"
+    "movq 40(%%rsp),%%r10\n"
+    "movq 48(%%rsp),%%r9\n"
+    "movq 56(%%rsp),%%r8\n"
+    "movq 64(%%rsp),%%rsi\n"
+    "movq 72(%%rsp),%%rdi\n"
+    "movq 80(%%rsp),%%rbp\n"
+    "movq 88(%%rsp),%%rdx\n"
+    "movq 96(%%rsp),%%rcx\n"
+    "movq 104(%%rsp),%%rbx\n"
+    "movq 112(%%rsp),%%rax\n"
+    "addq $120,%%rsp\n"
+    "movw 8(%%rsp),%%ds\n"
+    "movw (%%rsp),%%es\n"
+    "addq $32, %%rsp\n"
+    "iretq"
+    : : "g" ((uint64_t)tf) : "memory");
 }
 
 /* Switching the thread by activating the new thread's page
-   tables, and, if the previous thread is dying, destroying it.
+tables, and, if the previous thread is dying,destroying it.
 
    At this function's invocation, we just switched from thread
    PREV, the new thread is already running, and interrupts are
@@ -463,62 +509,62 @@ do_iret (struct intr_frame *tf) {
    complete.  In practice that means that printf()s should be
    added at the end of the function. */
 static void
-thread_launch (struct thread *th) {
-	uint64_t tf_cur = (uint64_t) &running_thread ()->tf;
-	uint64_t tf = (uint64_t) &th->tf;
-	ASSERT (intr_get_level () == INTR_OFF);
+thread_launch(struct thread* th) {
+  uint64_t tf_cur = (uint64_t)&running_thread()->tf;
+  uint64_t tf = (uint64_t)&th->tf;
+  ASSERT(intr_get_level() == INTR_OFF);
 
-	/* The main switching logic.
-	 * We first restore the whole execution context into the intr_frame
-	 * and then switching to the next thread by calling do_iret.
-	 * Note that, we SHOULD NOT use any stack from here
-	 * until switching is done. */
-	__asm __volatile (
-			/* Store registers that will be used. */
-			"push %%rax\n"
-			"push %%rbx\n"
-			"push %%rcx\n"
-			/* Fetch input once */
-			"movq %0, %%rax\n"
-			"movq %1, %%rcx\n"
-			"movq %%r15, 0(%%rax)\n"
-			"movq %%r14, 8(%%rax)\n"
-			"movq %%r13, 16(%%rax)\n"
-			"movq %%r12, 24(%%rax)\n"
-			"movq %%r11, 32(%%rax)\n"
-			"movq %%r10, 40(%%rax)\n"
-			"movq %%r9, 48(%%rax)\n"
-			"movq %%r8, 56(%%rax)\n"
-			"movq %%rsi, 64(%%rax)\n"
-			"movq %%rdi, 72(%%rax)\n"
-			"movq %%rbp, 80(%%rax)\n"
-			"movq %%rdx, 88(%%rax)\n"
-			"pop %%rbx\n"              // Saved rcx
-			"movq %%rbx, 96(%%rax)\n"
-			"pop %%rbx\n"              // Saved rbx
-			"movq %%rbx, 104(%%rax)\n"
-			"pop %%rbx\n"              // Saved rax
-			"movq %%rbx, 112(%%rax)\n"
-			"addq $120, %%rax\n"
-			"movw %%es, (%%rax)\n"
-			"movw %%ds, 8(%%rax)\n"
-			"addq $32, %%rax\n"
-			"call __next\n"         // read the current rip.
-			"__next:\n"
-			"pop %%rbx\n"
-			"addq $(out_iret -  __next), %%rbx\n"
-			"movq %%rbx, 0(%%rax)\n" // rip
-			"movw %%cs, 8(%%rax)\n"  // cs
-			"pushfq\n"
-			"popq %%rbx\n"
-			"mov %%rbx, 16(%%rax)\n" // eflags
-			"mov %%rsp, 24(%%rax)\n" // rsp
-			"movw %%ss, 32(%%rax)\n"
-			"mov %%rcx, %%rdi\n"
-			"call do_iret\n"
-			"out_iret:\n"
-			: : "g"(tf_cur), "g" (tf) : "memory"
-			);
+  /* The main switching logic.
+   * We first restore the whole execution context into the intr_frame
+   * and then switching to the next thread by calling do_iret.
+   * Note that, we SHOULD NOT use any stack from here
+   * until switching is done. */
+  __asm __volatile(
+  /* Store registers that will be used. */
+  "push %%rax\n"
+    "push %%rbx\n"
+    "push %%rcx\n"
+    /* Fetch input once */
+    "movq %0, %%rax\n"
+    "movq %1, %%rcx\n"
+    "movq %%r15, 0(%%rax)\n"
+    "movq %%r14, 8(%%rax)\n"
+    "movq %%r13, 16(%%rax)\n"
+    "movq %%r12, 24(%%rax)\n"
+    "movq %%r11, 32(%%rax)\n"
+    "movq %%r10, 40(%%rax)\n"
+    "movq %%r9, 48(%%rax)\n"
+    "movq %%r8, 56(%%rax)\n"
+    "movq %%rsi, 64(%%rax)\n"
+    "movq %%rdi, 72(%%rax)\n"
+    "movq %%rbp, 80(%%rax)\n"
+    "movq %%rdx, 88(%%rax)\n"
+    "pop %%rbx\n"              // Saved rcx
+    "movq %%rbx, 96(%%rax)\n"
+    "pop %%rbx\n"              // Saved rbx
+    "movq %%rbx, 104(%%rax)\n"
+    "pop %%rbx\n"              // Saved rax
+    "movq %%rbx, 112(%%rax)\n"
+    "addq $120, %%rax\n"
+    "movw %%es, (%%rax)\n"
+    "movw %%ds, 8(%%rax)\n"
+    "addq $32, %%rax\n"
+    "call __next\n"         // read the current rip.
+    "__next:\n"
+    "pop %%rbx\n"
+    "addq $(out_iret -  __next), %%rbx\n"
+    "movq %%rbx, 0(%%rax)\n" // rip
+    "movw %%cs, 8(%%rax)\n"  // cs
+    "pushfq\n"
+    "popq %%rbx\n"
+    "mov %%rbx, 16(%%rax)\n" // eflags
+    "mov %%rsp, 24(%%rax)\n" // rsp
+    "movw %%ss, 32(%%rax)\n"
+    "mov %%rcx, %%rdi\n"
+    "call do_iret\n"
+    "out_iret:\n"
+    : : "g"(tf_cur), "g" (tf) : "memory"
+    );
 }
 
 /* Schedules a new process. At entry, interrupts must be off.
@@ -527,64 +573,67 @@ thread_launch (struct thread *th) {
  * It's not safe to call printf() in the schedule(). */
 static void
 do_schedule(int status) {
-	ASSERT (intr_get_level () == INTR_OFF);
-	ASSERT (thread_current()->status == THREAD_RUNNING);
-	while (!list_empty (&destruction_req)) {
-		struct thread *victim =
-			list_entry (list_pop_front (&destruction_req), struct thread, elem);
-		palloc_free_page(victim);
-	}
-	thread_current ()->status = status;
-	schedule ();
+  ASSERT(intr_get_level() == INTR_OFF);
+  ASSERT(thread_current()->status == THREAD_RUNNING);
+  while (!list_empty(&destruction_req)) {
+    struct thread* victim =
+      list_entry(list_pop_front(&destruction_req), struct thread, elem);
+    palloc_free_page(victim);
+  }
+  thread_current()->status = status;
+  schedule();
 }
 
-static void
-schedule (void) {
-	struct thread *curr = running_thread ();
-	struct thread *next = next_thread_to_run ();
+static void schedule(void) {
+  enum intr_level old_level;
+  old_level = intr_disable();
 
-	ASSERT (intr_get_level () == INTR_OFF);
-	ASSERT (curr->status != THREAD_RUNNING);
-	ASSERT (is_thread (next));
-	/* Mark us as running. */
-	next->status = THREAD_RUNNING;
+  struct thread* curr = running_thread();
+  struct thread* next = next_thread_to_run();
 
-	/* Start new time slice. */
-	thread_ticks = 0;
+  ASSERT(intr_get_level() == INTR_OFF);
+  ASSERT(curr->status != THREAD_RUNNING);
+  ASSERT(is_thread(next));
+  /* Mark us as running. */
+  next->status = THREAD_RUNNING;
 
+  /* Start new time slice. */
+  thread_ticks = 0;
+
+  intr_set_level(old_level);
 #ifdef USERPROG
-	/* Activate the new address space. */
-	process_activate (next);
+  /* Activate the new address space. */
+  process_activate(next);
 #endif
 
-	if (curr != next) {
-		/* If the thread we switched from is dying, destroy its struct
-		   thread. This must happen late so that thread_exit() doesn't
-		   pull out the rug under itself.
-		   We just queuing the page free reqeust here because the page is
-		   currently used by the stack.
-		   The real destruction logic will be called at the beginning of the
-		   schedule(). */
-		if (curr && curr->status == THREAD_DYING && curr != initial_thread) {
-			ASSERT (curr != next);
-			list_push_back (&destruction_req, &curr->elem);
-		}
+  if (curr != next) {
+    /* If the thread we switched from is dying, destroy its struct
+       thread. This must happen late so that thread_exit() doesn't
+       pull out the rug under itself.
+       We just queuing the page free reqeust here because the page is
+       currently used by the stack.
+       The real destruction logic will be called at the beginning of the
+       schedule(). */
+    if (curr && curr->status == THREAD_DYING && curr != initial_thread) {
+      ASSERT(curr != next);
+      // list_push_back(&destruction_req, &curr->elem);
+      list_insert_ordered(&destruction_req, &curr->elem, value_less, NULL);
+    }
 
-		/* Before switching the thread, we first save the information
-		 * of current running. */
-		thread_launch (next);
-	}
+    /* Before switching the thread, we first save the information
+     * of current running. */
+    thread_launch(next);
+  }
 }
 
 /* Returns a tid to use for a new thread. */
-static tid_t
-allocate_tid (void) {
-	static tid_t next_tid = 1;
-	tid_t tid;
+static tid_t allocate_tid(void) {
+  static tid_t next_tid = 1;
+  tid_t tid;
 
-	lock_acquire (&tid_lock);
-	tid = next_tid++;
-	lock_release (&tid_lock);
+  lock_acquire(&tid_lock);
+  tid = next_tid++;
+  lock_release(&tid_lock);
 
-	return tid;
+  return tid;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #3

## 📝 작업 내용

> Priority Scheduling


### [ 우선순위 스케줄링 ]
1. ready list를 우선순위(`priority`) 기준으로 정렬하기
2. semaphore waiters를 우선순위(`priority`) 기준으로 정렬하기
3. condition waiters를 우선순위(`priority`) 기준으로 정렬하기

### [ 우선순위 역전 ]
- `lock_acquire()`
1. lock을 가진 스레드가 있다면, 우선순위를 비교하여 현재 스레드의 우선순위를 기부한다.(중첩 고려)
2. 현재 스레드의 순서가 되면 `sema_down()`을 호출하여 lock을 획득한다.

- `lock_release()`
1. 해당 lock을 반환하기 전, 우선순위를 기부받은 스레드 목록이 있다면 해당 lock으로 기부받은 스레드를 목록에서 삭제한다.
2. 기부받은 스레드가 변경되면, 현재 스레드의 우선순위를 갱신한다.
3. `sema_up()` 을 호출하여 lock을 반환한다. 

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/79a2fe1d-6245-46cc-8e2e-2aee85f76b12)

